### PR TITLE
9-cannot-remove-headers-after-they-are-sent-to-the-client bug fixed

### DIFF
--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .env
 .coverage
+yarn-error.log

--- a/server/middlewares/authAccessToken.ts
+++ b/server/middlewares/authAccessToken.ts
@@ -46,6 +46,7 @@ export default async function authAccessToken(request: Request, response: Respon
     }
 
     next();
+    return
 
   } catch (err: any) {
 
@@ -55,7 +56,5 @@ export default async function authAccessToken(request: Request, response: Respon
 
     return response.status(401).json({ message: "unauthenticated" })
   }
-
-  next();
 
 }


### PR DESCRIPTION
We managed to fix the bug by removing extra NextFuntion in the authAccessToken middleware